### PR TITLE
fix: correction filtre ecoledoctorale par lecture synchrone des queryParams

### DIFF
--- a/doctorat-gouv-backend/pom.xml
+++ b/doctorat-gouv-backend/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>fr.beta.gouv.doctorat</groupId>
 		<artifactId>doctorat-gouv</artifactId>
-		<version>0.2.9</version>
+		<version>0.2.10</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/doctorat-gouv-frontend/package-lock.json
+++ b/doctorat-gouv-frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doctorat-gouv-frontend",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "doctorat-gouv-frontend",
-      "version": "0.2.9",
+      "version": "0.2.10",
       "dependencies": {
         "@angular/common": "^20.3.0",
         "@angular/compiler": "^20.3.0",

--- a/doctorat-gouv-frontend/package.json
+++ b/doctorat-gouv-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doctorat-gouv-frontend",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/doctorat-gouv-frontend/pom.xml
+++ b/doctorat-gouv-frontend/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>fr.beta.gouv.doctorat</groupId>
 	<artifactId>doctorat-gouv-frontend</artifactId>
-	<version>0.2.9</version>
+	<version>0.2.10</version>
 	<packaging>pom</packaging>
 
 	<build>

--- a/doctorat-gouv-frontend/src/app/search/search.ts
+++ b/doctorat-gouv-frontend/src/app/search/search.ts
@@ -193,40 +193,40 @@ export class Search implements OnInit, OnDestroy {
 	  let urlHasEtablissementRor = false;
 	  let urlHasEcoleDoctorale = false;
 
-	  // Lire les paramètres d’URL 
-	  this.route.queryParams.subscribe(params => {
-		  if (params['ecoledoctorale']) {
+	  // Lecture synchrone des paramètres d'URL via le snapshot
+	  // (évite le problème de timing asynchrone de queryParams.subscribe)
+	  const urlParams = this.route.snapshot.queryParams;
+	  if (urlParams['ecoledoctorale']) {
 
-			  // Initialiser les filtres
-			  this.discipline = saved.discipline || []; 
-			  this.localisation = saved.localisation || [];
-			  this.laboratoire = saved.laboratoire || [];
-			  this.ecole = saved.ecole || [];
-			  this.defisSociete = saved.defisSociete || [];
-			  this.annee = saved.annee || [];
-			  this.etablissementRor = '';
-			  this.query = '';
+		  // Initialiser les filtres
+		  this.discipline = saved?.discipline || [];
+		  this.localisation = saved?.localisation || [];
+		  this.laboratoire = saved?.laboratoire || [];
+		  this.ecole = saved?.ecole || [];
+		  this.defisSociete = saved?.defisSociete || [];
+		  this.annee = saved?.annee || [];
+		  this.etablissementRor = '';
+		  this.query = '';
 
-			  this.ecoleDoctoraleNumero = params['ecoledoctorale'];
-			  urlHasEcoleDoctorale = true;   // 🔥 On note que l’URL contient le filtre école doctorale pour éviter de l’écraser plus tard
-		  };
-		  
-		  if (params['etablissementror']) { 
-			
-			// Initialiser les filtres
-			this.discipline = saved.discipline || []; 
-			this.localisation = saved.localisation || [];
-			this.laboratoire = saved.laboratoire || [];
-			this.ecole = saved.ecole || [];
-			this.defisSociete = saved.defisSociete || [];
-			this.annee = saved.annee || [];
-			this.ecoleDoctoraleNumero = '';
-			this.query = '';
-			
-			this.etablissementRor = params['etablissementror'];
-			urlHasEtablissementRor = true;   // 🔥 On note que l’URL contient le filtre ROR pour éviter de l’écraser plus tard
-		  }
-	  });
+		  this.ecoleDoctoraleNumero = urlParams['ecoledoctorale'];
+		  urlHasEcoleDoctorale = true;
+	  }
+
+	  if (urlParams['etablissementror']) {
+
+		  // Initialiser les filtres
+		  this.discipline = saved?.discipline || [];
+		  this.localisation = saved?.localisation || [];
+		  this.laboratoire = saved?.laboratoire || [];
+		  this.ecole = saved?.ecole || [];
+		  this.defisSociete = saved?.defisSociete || [];
+		  this.annee = saved?.annee || [];
+		  this.ecoleDoctoraleNumero = '';
+		  this.query = '';
+
+		  this.etablissementRor = urlParams['etablissementror'];
+		  urlHasEtablissementRor = true;
+	  }
 	  
 	  this.anneeOpts = this.generateYears();
 
@@ -235,12 +235,12 @@ export class Search implements OnInit, OnDestroy {
 	  
 	  if (saved) {
 	    this.query = saved.query || '';
-	    this.discipline = saved.discipline || '';
-	    this.localisation = saved.localisation || '';
-	    this.laboratoire = saved.laboratoire || '';
-	    this.ecole = saved.ecole || '';
-	    this.defisSociete = saved.defisSociete || '';
-		this.annee = saved.annee || '';
+	    this.discipline = Array.isArray(saved.discipline) ? saved.discipline : [];
+	    this.localisation = Array.isArray(saved.localisation) ? saved.localisation : [];
+	    this.laboratoire = Array.isArray(saved.laboratoire) ? saved.laboratoire : [];
+	    this.ecole = Array.isArray(saved.ecole) ? saved.ecole : [];
+	    this.defisSociete = Array.isArray(saved.defisSociete) ? saved.defisSociete : [];
+		this.annee = Array.isArray(saved.annee) ? saved.annee : [];
 		this.showMoreFilters = saved.showMoreFilters ?? false;
 		
 		// Ne PAS écraser la valeur venant de l’URL

--- a/doctorat-gouv-frontend/src/environments/environment.prod.ts
+++ b/doctorat-gouv-frontend/src/environments/environment.prod.ts
@@ -1,6 +1,6 @@
 export const environment = {
   production: true,
-  version: '0.2.9',
+  version: '0.2.10',
   matomoSiteId: 249,
   apiUrl: '/api'
   

--- a/doctorat-gouv-frontend/src/environments/environment.ts
+++ b/doctorat-gouv-frontend/src/environments/environment.ts
@@ -1,6 +1,6 @@
 export const environment = {
   production: false,
-  version: '0.2.9-beta',
+  version: '0.2.10-beta',
   matomoSiteId: 249,
   apiUrl: 'http://localhost:8080/api' // URL de dev
 };

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>fr.beta.gouv.doctorat</groupId>
 	<artifactId>doctorat-gouv</artifactId>
-	<version>0.2.9</version>
+	<version>0.2.10</version>
 	<packaging>pom</packaging>
 
 	<modules>


### PR DESCRIPTION
## Problème

Les URL `?ecoledoctorale=XXX` et `?etablissementror=XXX` ne filtrent plus les résultats.

**Cause racine :** `this.route.queryParams.subscribe()` peut émettre de façon asynchrone après la fin de `ngOnInit`. Quand `onSearch()` est appelée, le filtre n'a pas encore été positionné depuis l'URL → la requête API part sans filtre.

## Correction

1. Remplacement de `queryParams.subscribe` par `this.route.snapshot.queryParams` (lecture synchrone garantie)
2. Correction du type des filtres multi-valeurs (discipline, localisation, etc.) dans la restauration `sessionStorage` : `saved.discipline || ''` → `Array.isArray(saved.discipline) ? saved.discipline : []`
